### PR TITLE
remove tensorboard deps

### DIFF
--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -41,7 +41,6 @@ all = [
     "zstandard",                 # litgpt.data.prepare_slimpajama.py
     "pandas",                    # litgpt.data.prepare_starcoder.py
     "pyarrow",                   # litgpt.data.prepare_starcoder.py
-    "tensorboard",               # litgpt.pretrain
     "torchmetrics",              # litgpt.pretrain
     "safetensors",               # download
     "huggingface_hub[hf_transfer]>=0.21.0",  # download


### PR DESCRIPTION
this pr remove tensorboard from the dependency as it seems to create dependencies issue related to protobuf

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
grpcio-tools 1.65.1 requires protobuf<6.0dev,>=5.26.1, but you have protobuf 4.25.3 which is incompatible.
```