### PR TITLE
freeze torch version

### DIFF
--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 dependencies = [
-    "torch>=2.2.0",
+    "torch==2.3.1",
     "lightning>=2.3.3",
     "jsonargparse[signatures]>=4.27.6",
 ]


### PR DESCRIPTION
Torch 2.4 has been released, this pr fix the torch version to 2.3 to avoid problems since we did all of our tests with 2.3
