### PR TITLE
shell script to select training index file

### DIFF
--- a/train/README.md
+++ b/train/README.md
@@ -5,6 +5,10 @@ This directory contains code for (pre-)training of the metagenomic foundation mo
 Our code is based on [LitGPT](https://github.com/Lightning-AI/litgpt). See the LitGPT README
 [here](README-litgpt.md).
 
+## Selecting `index.json` file for training
+
+See [select_training_index_file.sh](select_training_index_file.sh).
+
 ## Quick Tour
 
 - Data

--- a/train/select_training_index_file.sh
+++ b/train/select_training_index_file.sh
@@ -1,0 +1,6 @@
+# To use the small training data file, run the following command:
+# (this has already been run, so the small data file is currently in use).
+aws s3 cp s3://mgfm-bucket-01/streams/index_files/index_10.json s3://mgfm-bucket-01/streams/index.json
+
+# To switch to large training data file, run the following command:
+#aws s3 cp s3://mgfm-bucket-01/streams/index_files/index_87.json s3://mgfm-bucket-01/streams/index.json


### PR DESCRIPTION
This is pretty hacky (really should make data file a CLI flag/config) — but for a quick fix:
- See `select_training_index_file.sh`
- If you want to switch to large data file, comment first line and uncomment second line, and run.
- Currently this will change the index file for both of us who are grabbing from the same S3 bucket :-).