### PR TITLE
Update evaluation.md

### DIFF
--- a/train/tutorials/evaluation.md
+++ b/train/tutorials/evaluation.md
@@ -62,6 +62,6 @@ For LoRA-finetuned models, you need to first merge the LoRA weights with the ori
       --save_filepath "results.json"
   ```
 
-* **Is Truthful MC is not available in lm-eval?**
+* **Is Truthful MC not available in lm-eval?**
 
   It is available as `truthfulqa_mc`.


### PR DESCRIPTION
fix(FAQ.md): correct question about Truthful MC availability

- Changed "Is Truthful MC is not available in lm-eval?"  to "Is Truthful MC not available in lm-eval?"

- Removes the repeated "is" for better clarity